### PR TITLE
solve js object deep equal

### DIFF
--- a/js-exercises/deep-equal/README.md
+++ b/js-exercises/deep-equal/README.md
@@ -1,0 +1,14 @@
+## Instructions
+
+Write a method that checks for equality with descriptors and without descriptors.
+Performs a deep comparison between two values to determine if they are equivalent.
+
+```js
+const obj = { a: 5 };
+
+const obj2 = {};
+Object.defineProperty(obj2, "a", { value: 5 });
+
+deepEqual(obj, obj2); //=> true
+deepEqual(obj, obj2, { matchDescriptors: true }); //=> false
+```

--- a/js-exercises/deep-equal/deepEqual.js
+++ b/js-exercises/deep-equal/deepEqual.js
@@ -1,10 +1,10 @@
-function deepEqual(object1, object2, compareDescriptor) {
-  if (!isObject(object1)) {
-    throw new TypeError(`expected object, got ${typeof object1}`);
+function deepEqual(firstObj, secondObj, compareDescriptor) {
+  if (!isObject(firstObj)) {
+    throw new TypeError(`expected object, got ${typeof firstObj}`);
   }
 
-  if (!isObject(object2)) {
-    throw new TypeError(`expected object, got ${typeof object2}`);
+  if (!isObject(secondObj)) {
+    throw new TypeError(`expected object, got ${typeof secondObj}`);
   }
 
   if (!isObject(compareDescriptor)) {
@@ -13,26 +13,26 @@ function deepEqual(object1, object2, compareDescriptor) {
 
   const shouldCompareDescriptor = compareDescriptor.matchDescriptors;
 
-  return isObjectEqual(object1, object2, shouldCompareDescriptor);
+  return isObjectEqual(firstObj, secondObj, shouldCompareDescriptor);
 
 }
 
-const isObjectEqual = (obj1, obj2, shouldCompareDescriptor) => {
+const isObjectEqual = (firstObj, secondObj, shouldCompareDescriptor) => {
 
   // check if objects have identical keys
-  const objectHasSameKeys = compareObjectKeys(obj1, obj2);
+  const objectHasSameKeys = compareObjectKeys(firstObj, secondObj);
   if (!objectHasSameKeys) {
     return false;
   }
-  const propertiesOfObj1 = Object.getOwnPropertyNames(obj1);
+  const propertiesOfFirstObj = Object.getOwnPropertyNames(firstObj);
 
-  for (const property of propertiesOfObj1) {
+  for (const property of propertiesOfFirstObj) {
     // if should compareDescrptor is true, compare the descriptor
     // if objects have different descriptor return false
     if (shouldCompareDescriptor) {
-      const descriptor1 = Object.getOwnPropertyDescriptor(obj1, property);
-      const descriptor2 = Object.getOwnPropertyDescriptor(obj2, property);
-      const hasSameDescriptor = compareDescriptor(descriptor1, descriptor2);
+      const descriptorOfFirstObj = Object.getOwnPropertyDescriptor(firstObj, property);
+      const descriptorOfSecondObj = Object.getOwnPropertyDescriptor(secondObj, property);
+      const hasSameDescriptor = compareDescriptor(descriptorOfFirstObj, descriptorOfSecondObj);
       if (!hasSameDescriptor) {
         return false;
       }
@@ -41,15 +41,15 @@ const isObjectEqual = (obj1, obj2, shouldCompareDescriptor) => {
     // compare values 
     // if value is not object then compare directly , otherwise recursively call 
     // isOjectEqual function
-    const val1 = obj1[property];
-    const val2 = obj2[property];
-    const isValObject = isObject(val1);
+    const firstVal = firstObj[property];
+    const secondVal = secondObj[property];
+    const isValObject = isObject(firstObj);
     if (!isValObject) {
-      if (val1 !== val2) {
+      if (firstVal !== secondVal) {
         return false;
       }
     } else {
-      if (!isObjectEqual(val1, val2, shouldCompareDescriptor)) {
+      if (!isObjectEqual(firstVal, secondVal, shouldCompareDescriptor)) {
         return false;
       }
     }
@@ -60,11 +60,11 @@ const isObjectEqual = (obj1, obj2, shouldCompareDescriptor) => {
    * then both the object is identical so return true
    */
   return true;
-}
+};
 
-const compareObjectKeys = (obj1, obj2) => {
-  const propertiesOfObj1 = Object.getOwnPropertyNames(obj1);
-  const propertiesOfObj2 = Object.getOwnPropertyNames(obj2);
+const compareObjectKeys = (firstObj, secondObj) => {
+  const propertiesOfObj1 = Object.getOwnPropertyNames(firstObj);
+  const propertiesOfObj2 = Object.getOwnPropertyNames(secondObj);
   const len1 = propertiesOfObj1.length;
   const len2 = propertiesOfObj2.length;
   if (len1 !== len2) {
@@ -77,23 +77,23 @@ const compareObjectKeys = (obj1, obj2) => {
     }
   }
   return true;
-}
+};
 
-const compareDescriptor = (descriptor1, descriptor2) => {
-  const keys = Object.getOwnPropertyNames(descriptor1);
+const compareDescriptor = (firstDescriptor, secondDescriptor) => {
+  const keys = Object.getOwnPropertyNames(firstDescriptor);
   for (const key of keys) {
     if (key !== 'value') {
-      const val1 = descriptor1[key];
-      const val2 = descriptor2[key];
+      const val1 = firstDescriptor[key];
+      const val2 = secondDescriptor[key];
       if (val1 !== val2) {
         return false;
       }
     }
   }
   return true;
-}
+};
 
-const isObject = (obj) => typeof obj === 'object';
+const isObject = (obj) => typeof obj === 'object' && typeof obj !== null;
 
 
 export {

--- a/js-exercises/deep-equal/deepEqual.js
+++ b/js-exercises/deep-equal/deepEqual.js
@@ -1,0 +1,103 @@
+function deepEqual(...args) {
+  const obj1 = args[0];
+  const obj2 = args[1];
+  const obj3 = args[2];
+  const isNotObject = typeof obj1 !== 'object' || typeof obj2 !== 'object' || typeof obj3 !== 'object';
+  if (isNotObject) {
+    throw new TypeError(`only objects are allowed`);
+  }
+  const shouldCompareDescriptor = obj3.matchDescriptors;
+  return compareObject(obj1, obj2, shouldCompareDescriptor);
+
+}
+
+const compareObject = (obj1, obj2, shouldCompareDescriptor) => {
+  for (const key in obj1) {
+
+    // if both the object has not same property return false
+    const hasProperty = obj1.hasOwnProperty(key) === obj2.hasOwnProperty(key);
+    if (!hasProperty) {
+      return false;
+    }
+
+    // compare the object descriptor , if its not true return false
+    if (shouldCompareDescriptor) {
+      const obj1Descriptor = Object.getOwnPropertyDescriptor(obj1, key);
+      const obj2Descriptor = Object.getOwnPropertyDescriptor(obj2, key);
+      const objectsHasSameDescripor = comareDescriptor(obj1Descriptor, obj2Descriptor)
+      if (!objectsHasSameDescripor) {
+        return false;
+      }
+    }
+
+    // if value of object property is not an object directly compare its value
+    // if value is again a object recursively call this compareObject method
+    if (!isObject(obj1[key])) {
+      if (obj1[key] !== obj2[key]) {
+        return false;
+      }
+    } else {
+      const isValObject = isObject(obj2[key]);
+      if (!isValObject || !compareObject(obj1[key], obj2[key], shouldCompareDescriptor)) {
+        return false;
+      }
+    }
+  }
+
+  // if obj2 and 
+  for (const key in obj2) {
+    if (obj2.hasOwnProperty(key)) {
+      if (!obj1.hasOwnProperty(key)) {
+        return false;
+      }
+    }
+  }
+
+  return true;
+}
+
+// compare the descriptoe
+const comareDescriptor = (obj1, obj2) => {
+  return isObjectkeyValEqual(obj1, obj2, 'value');
+}
+
+
+const isObjectkeyValEqual = (obj1, obj2, EscapeVal) => {
+  for (const key in obj1) {
+    if (key !== EscapeVal) {
+      if (obj1.hasOwnProperty(key) !== obj2.hasOwnProperty(key)) {
+        return false;
+      }
+      if (obj1[key] !== obj2[key]) {
+        return false;
+      }
+    }
+  }
+
+
+  for (const key in obj2) {
+    if (key !== EscapeVal) {
+      if (obj2.hasOwnProperty(key)) {
+        if (!obj1.hasOwnProperty(key)) {
+          return false;
+        }
+      }
+    }
+  }
+  return true;
+}
+
+const isObject = (obj) => typeof obj === 'object';
+
+// const obj1 = {};
+
+// const obj2 = {};
+// Object.defineProperty(obj2, "a", { value: 5 });
+// Object.defineProperty(obj1, "a", { value: 4 });
+// console.log(compareObject(obj2, obj1, true));
+
+// console.log(compareObject({ a: { b: { c: { d: 4 } } }, e: 3, f: { g: {} } }, { a: { b: { c: { d: 4 } } }, e: 3, f: { g: { x: 6 } } }, true));
+
+export {
+  deepEqual,
+};

--- a/js-exercises/deep-equal/deepEqual.test.js
+++ b/js-exercises/deep-equal/deepEqual.test.js
@@ -1,0 +1,31 @@
+import { deepEqual } from "./deepEqual";
+
+describe("Template Test", () => {
+  test("Shoud accept only objects", () => {
+    try {
+      deepEqual({}, 5, 4)
+    } catch (e) {
+      expect(e).toBeTruthy()
+    }
+  });
+
+  test("Shoud return correct answer in case of simple object", () => {
+    expect(deepEqual({ a: 5, b: 6 }, { a: 5, b: 6 }, { matchDescriptors: true })).toBe(true);
+  });
+
+  test("Shoud return correct answer in case of complex object", () => {
+    expect(deepEqual({ a: { b: { c: { d: 4 } } }, e: 3, f: { g: {} } }, { a: { b: { c: { d: 4 } } }, e: 3, f: { g: { x: 6 } } }, { matchDescriptors: true })).toBe(false);
+  });
+
+  test("Shoud return correct answer in case of complex object", () => {
+    expect(deepEqual({ a: { b: { c: { d: 4 } } }, e: 3, f: { g: { x: 6 } } }, { a: { b: { c: { d: 4 } } }, e: 3, f: { g: { x: 6 } } }, { matchDescriptors: true })).toBe(true);
+  });
+
+  test("Shoud return correct answer in case of different descriptor", () => {
+    const obj = { a: 5 };
+    const obj2 = {};
+    Object.defineProperty(obj2, "a", { value: 5 });
+    expect(deepEqual(obj, obj2, { matchDescriptors: false })).toBe(true);
+    expect(deepEqual(obj, obj2, { matchDescriptors: true })).toBe(false);
+  });
+});

--- a/js-exercises/deep-equal/deepEqual.test.js
+++ b/js-exercises/deep-equal/deepEqual.test.js
@@ -22,6 +22,15 @@ describe("Template Test", () => {
   });
 
   test("Shoud return correct answer in case of different descriptor", () => {
+    const obj = {};
+    const obj2 = {};
+    Object.defineProperty(obj2, "a", { value: 5 });
+    Object.defineProperty(obj, "a", { value: 5 });
+    expect(deepEqual(obj, obj2, { matchDescriptors: false })).toBe(true);
+    expect(deepEqual(obj, obj2, { matchDescriptors: true })).toBe(true);
+  });
+
+  test("Shoud return correct answer in case of different descriptor", () => {
     const obj = { a: 5 };
     const obj2 = {};
     Object.defineProperty(obj2, "a", { value: 5 });


### PR DESCRIPTION
solved the question related to comparing objects:
Following test cases are taken care of:

1. should compare normal objects
2. should compare deep objects like` {a: {b:{}}}`
3. should consider objects descriptor while comparing.