### PR TITLE
solve accessor properties problem

### DIFF
--- a/js-exercises/accessor-properties/README.md
+++ b/js-exercises/accessor-properties/README.md
@@ -1,0 +1,13 @@
+## Instructions
+
+Given an object, set a property `number` such that when the value is set to a decimal, it's binary is returned when accessed. See example for more info --
+
+```js
+const obj = accessorProperties();
+obj.number = 36;
+console.log(obj.number); // 100100
+```
+
+Write tests for it as well.
+
+- Assert on the accessor property.

--- a/js-exercises/accessor-properties/accessorProperties.js
+++ b/js-exercises/accessor-properties/accessorProperties.js
@@ -1,0 +1,29 @@
+
+const isValidNumber = (num) => typeof num === 'number' && !Number.isNaN(num);
+
+function accessorProperties() {
+  const obj = {
+    _number: '',
+    get number() {
+      if (this._number >= 0) {
+        return this._number.toString(2);
+      } else {
+        return (this._number >>> 0).toString(2);
+      }
+    },
+
+    set number(num) {
+      if (isValidNumber(num)) {
+        this._number = num;
+      } else {
+        throw new TypeError('Only valid numbers are allowed');
+      }
+    },
+  };
+
+  return obj;
+}
+
+export {
+  accessorProperties,
+};

--- a/js-exercises/accessor-properties/accessorProperties.test.js
+++ b/js-exercises/accessor-properties/accessorProperties.test.js
@@ -1,0 +1,25 @@
+import { accessorProperties } from "./accessorProperties";
+
+describe("Template Test", () => {
+  test("should only set numbers", () => {
+    const obj = accessorProperties();
+    expect(() => { obj.number = null; }).toThrow(TypeError);
+    expect(() => { obj.number = undefined; }).toThrow(TypeError);
+    expect(() => { obj.number = NaN; }).toThrow(TypeError);
+    expect(() => { obj.number = []; }).toThrow(TypeError);
+  });
+
+  test("should return correct result for positive numbers", () => {
+    const obj = accessorProperties();
+    obj.number = 5;
+    const result = obj.number;
+    expect(result).toBe('101');
+  });
+
+  test("should return correct result for negative numbers", () => {
+    const obj = accessorProperties();
+    obj.number = -5;
+    const result = obj.number;
+    expect(result).toBe('11111111111111111111111111111011');
+  });
+});


### PR DESCRIPTION
solved accessor properties problem.
**Problem statement**: Given an object, set a property `number` such that when the value is set to a decimal, it's binary is returned when accessed.

Following test cases have been taken care of:
1. only numbers are allowed 
2. handled a negative number, in case of a negative number, its  **signed 2's complement** is returned.


